### PR TITLE
feat: add proper cli for management

### DIFF
--- a/device-pool-cli/pom.xml
+++ b/device-pool-cli/pom.xml
@@ -31,7 +31,7 @@
                             </artifactSet>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>me.philcali.device.pool.example.ExampleApp</mainClass>
+                                    <mainClass>me.philcali.device.pool.cli.DeviceLabCLI</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/device-pool-cli/pom.xml
+++ b/device-pool-cli/pom.xml
@@ -9,8 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>device-pool-examples</artifactId>
-
+    <artifactId>device-pool-cli</artifactId>
 
     <build>
         <plugins>
@@ -44,26 +43,23 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j18-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
             <version>${picocli.version}</version>
         </dependency>
-        <!-- Needed for SSH device interaction -->
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
-            <artifactId>device-pool-ssh</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <!-- Needed for EC2 provisioning -->
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>device-pool-ec2</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <!-- Needed for Device Lab provisioning -->
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>device-pool-client</artifactId>
+            <artifactId>device-pool-service-client</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/device-pool-cli/src/main/java/me/philcali/device/pool/cli/DeviceLabCLI.java
+++ b/device-pool-cli/src/main/java/me/philcali/device/pool/cli/DeviceLabCLI.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2022 Philip Cali
+ * Released under Apache-2.0 License
+ *     (https://www.apache.org/licenses/LICENSE-2.0)
+ */
+
+package me.philcali.device.pool.cli;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import me.philcali.device.pool.service.api.model.CreateDeviceObject;
+import me.philcali.device.pool.service.api.model.CreateDevicePoolObject;
+import me.philcali.device.pool.service.api.model.CreateProvisionObject;
+import me.philcali.device.pool.service.api.model.DevicePoolEndpoint;
+import me.philcali.device.pool.service.api.model.DevicePoolEndpointType;
+import me.philcali.device.pool.service.api.model.DevicePoolLockOptions;
+import me.philcali.device.pool.service.api.model.DevicePoolType;
+import me.philcali.device.pool.service.api.model.UpdateDeviceObject;
+import me.philcali.device.pool.service.api.model.UpdateDevicePoolObject;
+import me.philcali.device.pool.service.client.AwsV4SigningInterceptor;
+import me.philcali.device.pool.service.client.DeviceLabService;
+import picocli.CommandLine;
+import retrofit2.Call;
+import retrofit2.Response;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+@CommandLine.Command(
+        name = "device-lab",
+        description = "Device Lab CLI for the control plane",
+        subcommands = {CommandLine.HelpCommand.class}
+)
+public class DeviceLabCLI {
+    @CommandLine.Option(
+            names = "--endpoint",
+            description = "Endpoint override",
+            required = true
+    )
+    String endpoint;
+
+    @CommandLine.Option(
+            names = {"-v", "--verbose"},
+            description = "Verbose flag to output wire details"
+    )
+    boolean verbose;
+
+    final ObjectMapper mapper;
+
+    private DeviceLabCLI() {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+    }
+
+    public static void main(String[] args) {
+        System.exit(new CommandLine(new DeviceLabCLI()).execute(args));
+    }
+
+    private DeviceLabService createService() {
+        return DeviceLabService.create((client, builder) -> {
+           client.addInterceptor(AwsV4SigningInterceptor.create());
+           builder.baseUrl(endpoint);
+        });
+    }
+
+    private void executeAndPrint(Call<?> call) {
+        try {
+            if (verbose) {
+                System.out.println("Request URL: " + call.request().url().uri());
+                System.out.println("Request Method: " + call.request().method());
+            }
+            Response<?> response = call.execute();
+            if (verbose) {
+                System.out.println("Response Status: " + response.code());
+                System.out.println("Response Headers: ");
+                System.out.println(response.headers());
+            }
+            if (Objects.nonNull(response.errorBody())) {
+                System.err.println(response.errorBody().string());
+            } else {
+                mapper.writeValue(System.out, response.body());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @CommandLine.Command(
+            name = "list-device-pools",
+            description = "List device pools"
+    )
+    public void listDevicePools(
+            @CommandLine.Option(names = "--next-token") String nextToken,
+            @CommandLine.Option(names = "--limit") Integer limit
+    ) {
+       executeAndPrint(createService().listDevicePools(nextToken, limit));
+    }
+
+    @CommandLine.Command(
+            name = "list-devices",
+            description = "List devices to device pools"
+    )
+    public void listDevices(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--next-token") String nextToken,
+            @CommandLine.Option(names = "--limit") Integer limit
+    ) {
+        executeAndPrint(createService().listDevices(poolId, nextToken, limit));
+    }
+
+    @CommandLine.Command(
+            name = "list-provisions",
+            description = "List provision requests to device pools"
+    )
+    public void listProvisions(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--next-token") String nextToken,
+            @CommandLine.Option(names = "--limit") Integer limit
+    ) {
+        executeAndPrint(createService().listProvisions(poolId, nextToken, limit));
+    }
+
+    @CommandLine.Command(
+            name = "list-reservations",
+            description = "List device reservation requests to provisions"
+    )
+    public void listReservations(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--provision-id", required = true) String provisionId,
+            @CommandLine.Option(names = "--next-token") String nextToken,
+            @CommandLine.Option(names = "--limit") Integer limit
+    ) {
+        executeAndPrint(createService().listReservations(poolId, provisionId, nextToken, limit));
+    }
+
+    @CommandLine.Command(
+            name = "get-device-pool",
+            description = "Obtains a single device pool metadata"
+    )
+    public void getDevicePool(
+            @CommandLine.Option(names = "--pool-id") String poolId
+    ) {
+        executeAndPrint(createService().getDevicePool(poolId));
+    }
+
+    @CommandLine.Command(
+            name = "get-device",
+            description = "Obtains a single device metadata"
+    )
+    public void getDevice(
+            @CommandLine.Option(names = "--pool-id") String poolId,
+            @CommandLine.Option(names = "--device-id") String deviceId
+    ) {
+        executeAndPrint(createService().getDevice(poolId, deviceId));
+    }
+
+    @CommandLine.Command(
+            name = "get-provision",
+            description = "Obtains a single provision request metadata"
+    )
+    public void getProvision(
+            String poolId,
+            String reservationId
+    ) {
+        executeAndPrint(createService().getProvision(poolId, reservationId));
+    }
+
+    @CommandLine.Command(
+            name = "get-reservation",
+            description = "Obtains a single device reservation"
+    )
+    public void getReservation(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--provision-id", required = true) String provisionId,
+            @CommandLine.Option(names = "--reservation-id", required = true) String reservationId
+    ) {
+        executeAndPrint(createService().getReservation(poolId, provisionId, reservationId));
+    }
+
+    @CommandLine.Command(
+            name = "create-device-pool",
+            description = "Creates a single device pool"
+    )
+    public void createDevicePool(
+            @CommandLine.Option(names = "--pool-id", required = true) String name,
+            @CommandLine.Option(names = "--description") String description,
+            @CommandLine.Option(names = "--type", defaultValue = "MANAGED") String type,
+            @CommandLine.Option(names = "--endpoint-type") String endpointType,
+            @CommandLine.Option(names = "--endpoint-uri") String endpointUri,
+            @CommandLine.Option(names = "--lock-options-duration") Long duration,
+            @CommandLine.Option(names = "--lock-options-enabled") boolean enabled
+    ) {
+        DevicePoolEndpoint endpoint = null;
+        if (Objects.nonNull(endpointUri) || Objects.nonNull(endpointType)) {
+            endpoint = DevicePoolEndpoint.builder()
+                    .uri(endpointUri)
+                    .type(DevicePoolEndpointType.valueOf(endpointUri))
+                    .build();
+        }
+        DevicePoolLockOptions lockOptions = DevicePoolLockOptions.builder()
+                .enabled(enabled)
+                .duration(duration)
+                .build();
+        executeAndPrint(createService().createDevicePool(CreateDevicePoolObject.builder()
+                .type(DevicePoolType.valueOf(type.toUpperCase()))
+                .description(description)
+                .endpoint(endpoint)
+                .lockOptions(lockOptions)
+                .name(name)
+                .build()));
+    }
+
+    @CommandLine.Command(
+            name = "create-device",
+            description = "Creates a single device for a device pool"
+    )
+    public void createDevice(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--device-id", required = true) String deviceId,
+            @CommandLine.Option(names = "--public-address", required = true) String publicAddress,
+            @CommandLine.Option(names = "--private-address") String privateAddress,
+            @CommandLine.Option(names = "--expires-in") Instant expiresIn
+    ) {
+        executeAndPrint(createService().createDevice(poolId, CreateDeviceObject.builder()
+                .id(deviceId)
+                .publicAddress(publicAddress)
+                .privateAddress(privateAddress)
+                .expiresIn(expiresIn)
+                .build()));
+    }
+
+    @CommandLine.Command(
+            name = "create-provision",
+            description = "Creates a single provision request"
+    )
+    public void createProvision(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--id", required = true) String id,
+            @CommandLine.Option(names = "--amount", description = "1") int amount,
+            @CommandLine.Option(names = "--expires-in") Instant expiresIn
+    ) {
+        executeAndPrint(createService().createProvision(poolId, CreateProvisionObject.builder()
+                .id(id)
+                .amount(amount)
+                .expiresIn(expiresIn)
+                .build()));
+    }
+
+    @CommandLine.Command(
+            name = "update-device-pool",
+            description = "Updates a single device pool record"
+    )
+    public void updateDevicePool(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--description") String description,
+            @CommandLine.Option(names = "--type") String type,
+            @CommandLine.Option(names = "--endpoint-type") String endpointType,
+            @CommandLine.Option(names = "--endpoint-uri") String endpointUri,
+            @CommandLine.Option(names = "--lock-options-duration") Long duration,
+            @CommandLine.Option(names = "--lock-options-enabled") Boolean enabled
+    ) {
+        DevicePoolEndpoint endpoint = null;
+        if (Objects.nonNull(endpointUri) || Objects.nonNull(endpointType)) {
+            endpoint = DevicePoolEndpoint.builder()
+                    .uri(endpointUri)
+                    .type(DevicePoolEndpointType.valueOf(endpointUri))
+                    .build();
+        }
+        DevicePoolLockOptions lockOptions = null;
+        if (Objects.nonNull(enabled)) {
+            lockOptions = DevicePoolLockOptions.builder()
+                    .enabled(enabled)
+                    .duration(duration)
+                    .build();
+        }
+        executeAndPrint(createService().updateDevicePool(poolId, UpdateDevicePoolObject.builder()
+                .description(description)
+                .type(Optional.ofNullable(type).map(DevicePoolType::valueOf).orElse(null))
+                .lockOptions(lockOptions)
+                .endpoint(endpoint)
+                .build()));
+    }
+
+    @CommandLine.Command(
+            name = "update-device",
+            description = "Updates a single device metadata record"
+    )
+    public void updateDevice(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--device-id", required = true) String deviceId,
+            @CommandLine.Option(names = "--public-address") String publicAddress,
+            @CommandLine.Option(names = "--private-address") String privateAddress,
+            @CommandLine.Option(names = "--expires-in") Instant expiresIn
+    ) {
+        executeAndPrint(createService().updateDevice(poolId, deviceId, UpdateDeviceObject.builder()
+                .publicAddress(publicAddress)
+                .privateAddress(privateAddress)
+                .expiresIn(expiresIn)
+                .build()));
+    }
+
+    @CommandLine.Command(
+            name = "cancel-provision",
+            description = "Cancel a single non-terminal provision request"
+    )
+    public void cancelProvision(
+            @CommandLine.Option(names = "--pool-id") String poolId,
+            @CommandLine.Option(names = "--provision-id") String provisionId
+    ) {
+        executeAndPrint(createService().cancelProvision(poolId, provisionId));
+    }
+
+    @CommandLine.Command(
+            name = "delete-provision",
+            description = "Deletes a single terminal provision request"
+    )
+    public void deleteProvision(
+            @CommandLine.Option(names = "--pool-id") String poolId,
+            @CommandLine.Option(names = "--provision-id") String provisionId
+    ) {
+        executeAndPrint(createService().deleteProvision(poolId, provisionId));
+    }
+
+    @CommandLine.Command(
+            name = "cancel-reservation",
+            description = "Cancels a single non-terminal device reservation"
+    )
+    public void cancelReservation(
+            @CommandLine.Option(names = "--pool-id", required = true) String poolId,
+            @CommandLine.Option(names = "--provision-id", required = true) String provisionId,
+            @CommandLine.Option(names = "--reservation-id", required = true) String reservationId
+    ) {
+        executeAndPrint(createService().cancelReservation(poolId, provisionId, reservationId));
+    }
+}

--- a/device-pool-cli/src/main/resources/log4j2.xml
+++ b/device-pool-cli/src/main/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration packages="com.amazonaws.services.lambda.runtime.log4j2" status="INFO">
+    <Appenders>
+        <Console name="Console">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1} - %m%n</pattern>
+            </PatternLayout>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/device-pool-service/device-pool-service-api/src/main/java/me/philcali/device/pool/service/api/model/DevicePoolLockOptionsModel.java
+++ b/device-pool-service/device-pool-service-api/src/main/java/me/philcali/device/pool/service/api/model/DevicePoolLockOptionsModel.java
@@ -15,11 +15,17 @@ import java.time.Duration;
 @ApiModel
 @Value.Immutable
 @JsonDeserialize(as = DevicePoolLockOptions.class)
-abstract class DevicePoolLockOptionsModel {
-    abstract boolean enabled();
+interface DevicePoolLockOptionsModel {
+    boolean enabled();
 
     @Value.Default
-    Long initialDuration() {
+    @Deprecated
+    default long initialDuration() {
+        return duration();
+    }
+
+    @Value.Default
+    default long duration() {
         return Duration.ofHours(1).toSeconds();
     }
 }

--- a/device-pool-service/device-pool-service-client/pom.xml
+++ b/device-pool-service/device-pool-service-client/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>device-pool-service-client</artifactId>
 
     <properties>
-        <retrofit2.version>2.9.0</retrofit2.version>
+        <retrofit2.version>2.7.1</retrofit2.version>
     </properties>
 
     <build>

--- a/device-pool-service/device-pool-service-data/src/main/java/me/philcali/device/pool/service/data/ProvisionRepoDynamo.java
+++ b/device-pool-service/device-pool-service-data/src/main/java/me/philcali/device/pool/service/data/ProvisionRepoDynamo.java
@@ -8,7 +8,6 @@ package me.philcali.device.pool.service.data;
 
 import me.philcali.device.pool.model.Status;
 import me.philcali.device.pool.service.api.ProvisionRepo;
-import me.philcali.device.pool.service.api.exception.ServiceException;
 import me.philcali.device.pool.service.api.model.CompositeKey;
 import me.philcali.device.pool.service.api.model.CreateProvisionObject;
 import me.philcali.device.pool.service.api.model.ProvisionObject;
@@ -94,7 +93,8 @@ public class ProvisionRepoDynamo
         Expression.Builder builder = Expression.builder();
         int index = 0;
         for (Status status : Status.values()) {
-            if (status.isTerminal()) {
+            // We allow an exception fo cancelling, since we need to seed the stream
+            if (status.isTerminal() || status == Status.CANCELING) {
                 String valueKey = ":s" + (++index);
                 statusValueKeys.add(valueKey);
                 builder.putExpressionValue(valueKey, AttributeValue.builder()

--- a/device-pool-service/device-pool-service-data/src/main/java/me/philcali/device/pool/service/data/TableSchemas.java
+++ b/device-pool-service/device-pool-service-data/src/main/java/me/philcali/device/pool/service/data/TableSchemas.java
@@ -67,9 +67,9 @@ public class TableSchemas {
                 .addAttribute(Boolean.class, a -> a.name("enabled")
                         .getter(DevicePoolLockOptions::enabled)
                         .setter(DevicePoolLockOptions.Builder::enabled))
-                .addAttribute(Long.class, a -> a.name("initialDuration")
-                        .getter(DevicePoolLockOptions::initialDuration)
-                        .setter(DevicePoolLockOptions.Builder::initialDuration))
+                .addAttribute(Long.class, a -> a.name("duration")
+                        .getter(DevicePoolLockOptions::duration)
+                        .setter(DevicePoolLockOptions.Builder::duration))
                 .build();
     }
 

--- a/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/event/CancelProvisionWorkflowFunction.java
+++ b/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/event/CancelProvisionWorkflowFunction.java
@@ -11,6 +11,8 @@ import com.amazonaws.services.lambda.runtime.events.models.dynamodb.Record;
 import me.philcali.device.pool.model.Status;
 import me.philcali.device.pool.service.api.ProvisionRepo;
 import me.philcali.device.pool.service.api.ReservationRepo;
+import me.philcali.device.pool.service.api.exception.InvalidInputException;
+import me.philcali.device.pool.service.api.exception.NotFoundException;
 import me.philcali.device.pool.service.api.model.ProvisionObject;
 import me.philcali.device.pool.service.api.model.UpdateProvisionObject;
 import me.philcali.device.pool.service.api.model.UpdateReservationObject;
@@ -69,6 +71,8 @@ public class CancelProvisionWorkflowFunction implements DevicePoolEventRouterFun
         try {
             ProvisionObject updated = execute(provision);
             LOGGER.info("Canceled provision {}", updated);
+        } catch (NotFoundException | InvalidInputException e) {
+            LOGGER.warn("Provision no longer exists {}", provision.id());
         } catch (WorkflowExecutionException e) {
             LOGGER.error("Failed to cancel execution for {}", provision, e);
         }

--- a/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/workflow/CreateReservationStep.java
+++ b/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/workflow/CreateReservationStep.java
@@ -88,7 +88,7 @@ public class CreateReservationStep implements WorkflowStep<WorkflowState, Workfl
                     try {
                         lockRepo.create(device.selfKey(), CreateLockObject.builder()
                                 .holder(reservationId)
-                                .duration(Duration.ofSeconds(input.poolLockOptions().initialDuration()))
+                                .duration(Duration.ofSeconds(input.poolLockOptions().duration()))
                                 .build());
                         LOGGER.info("Obtained a lock on the device");
                     } catch (ConflictException ce) {

--- a/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/workflow/FinishProvisionStep.java
+++ b/device-pool-service/device-pool-service-events/src/main/java/me/philcali/device/pool/service/workflow/FinishProvisionStep.java
@@ -9,6 +9,7 @@ package me.philcali.device.pool.service.workflow;
 import me.philcali.device.pool.model.Status;
 import me.philcali.device.pool.service.api.ProvisionRepo;
 import me.philcali.device.pool.service.api.ReservationRepo;
+import me.philcali.device.pool.service.api.exception.InvalidInputException;
 import me.philcali.device.pool.service.api.exception.NotFoundException;
 import me.philcali.device.pool.service.api.exception.ServiceException;
 import me.philcali.device.pool.service.api.model.ReservationObject;
@@ -60,9 +61,9 @@ public class FinishProvisionStep implements WorkflowStep<WorkflowState, Workflow
                     .from(input)
                     .provision(provisionRepo.update(input.key().parentKey(), update.build()))
                     .build();
-        } catch (NotFoundException e) {
-            LOGGER.error("Provision with key {} was not found", input.provision().selfKey());
-            throw new WorkflowExecutionException(e);
+        } catch (NotFoundException | InvalidInputException e) {
+            LOGGER.warn("Provision with key {} was not found", input.provision().selfKey());
+            return input;
         } catch (ServiceException e) {
             LOGGER.error("Failed to update provision {}, retrying", input.provision().selfKey(), e);
             throw new RetryableException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>device-pool-service</module>
         <module>device-pool-client</module>
         <module>device-pool-examples</module>
+        <module>device-pool-cli</module>
     </modules>
 
     <properties>
@@ -44,6 +45,7 @@
         <enforcer.version>3.0.0-M2</enforcer.version>
         <ddb.local.version>1.16.0</ddb.local.version>
         <aws.sdk.version>2.16.52</aws.sdk.version>
+        <picocli.version>4.6.2</picocli.version>
     </properties>
 
     <reporting>


### PR DESCRIPTION
- Adds a cli
- Fixes some worflow bugs

Fixes #24 

``` bash
Usage: device-lab [-v] --endpoint=<endpoint> [COMMAND]
Device Lab CLI for the control plane
      --endpoint=<endpoint>
                  Endpoint override
  -v, --verbose   Verbose flag to output wire details
Commands:
  help                Displays help information about the specified command
  cancel-provision    Cancel a single non-terminal provision request
  cancel-reservation  Cancels a single non-terminal device reservation
  create-device       Creates a single device for a device pool
  create-device-pool  Creates a single device pool
  create-provision    Creates a single provision request
  delete-provision    Deletes a single terminal provision request
  get-device          Obtains a single device metadata
  get-device-pool     Obtains a single device pool metadata
  get-provision       Obtains a single provision request metadata
  get-reservation     Obtains a single device reservation
  list-device-pools   List device pools
  list-devices        List devices to device pools
  list-provisions     List provision requests to device pools
  list-reservations   List device reservation requests to provisions
  update-device       Updates a single device metadata record
  update-device-pool  Updates a single device pool record
```
