### PR TITLE
fix: make platform usage consistent

### DIFF
--- a/device-pool-ec2/src/main/java/me/philcali/device/pool/ec2/Ec2ReservationService.java
+++ b/device-pool-ec2/src/main/java/me/philcali/device/pool/ec2/Ec2ReservationService.java
@@ -38,7 +38,7 @@ public abstract class Ec2ReservationService implements ReservationService {
         return Ec2Client.create();
     }
 
-    abstract PlatformOS platformOS();
+    abstract PlatformOS platform();
 
     @Nullable
     abstract String proxyJump();
@@ -50,7 +50,7 @@ public abstract class Ec2ReservationService implements ReservationService {
 
     @Value.Default
     Function<Instance, PlatformOS> hostPlatform() {
-        return instance -> platformOS();
+        return instance -> platform();
     }
 
     @Value.Default
@@ -63,7 +63,7 @@ public abstract class Ec2ReservationService implements ReservationService {
     }
 
     public static Ec2ReservationService of(PlatformOS platformOS) {
-        return builder().platformOS(platformOS).build();
+        return builder().platform(platformOS).build();
     }
 
     public static final class Builder
@@ -80,7 +80,7 @@ public abstract class Ec2ReservationService implements ReservationService {
                                 .ifPresent(usePrivate -> hostAddress(Instance::privateIpAddress));
                         return entry.get("platform")
                                 .map(PlatformOS::fromString)
-                                .map(this::platformOS)
+                                .map(this::platform)
                                 .map(ImmutableEc2ReservationService.Builder::build);
                     })
                     .orElseThrow(() -> new ReservationException("The ec2 reservation requires a platform property"));

--- a/device-pool-ec2/src/test/java/me/philcali/device/pool/ec2/Ec2ReservationServiceTest.java
+++ b/device-pool-ec2/src/test/java/me/philcali/device/pool/ec2/Ec2ReservationServiceTest.java
@@ -8,7 +8,6 @@ package me.philcali.device.pool.ec2;
 
 import me.philcali.device.pool.configuration.DevicePoolConfig;
 import me.philcali.device.pool.configuration.DevicePoolConfigProperties;
-import me.philcali.device.pool.exceptions.ProvisioningException;
 import me.philcali.device.pool.exceptions.ReservationException;
 import me.philcali.device.pool.model.Host;
 import me.philcali.device.pool.model.PlatformOS;
@@ -47,7 +46,7 @@ class Ec2ReservationServiceTest {
         service = Ec2ReservationService.builder()
                 .ec2(ec2)
                 .proxyJump("proxy-host.amazon.com")
-                .platformOS(PlatformOS.of("Linux", "aarch64"))
+                .platform(PlatformOS.of("Linux", "aarch64"))
                 .build();
 
         reservation = Reservation.builder()
@@ -73,7 +72,7 @@ class Ec2ReservationServiceTest {
         Host expectedHost = Host.builder()
                 .port(22)
                 .hostName("10.0.6.1")
-                .platform(service.platformOS())
+                .platform(service.platform())
                 .proxyJump(service.proxyJump())
                 .deviceId(reservation.deviceId())
                 .build();
@@ -100,7 +99,7 @@ class Ec2ReservationServiceTest {
     void GIVEN_no_service_WHEN_config_is_used_THEN_service_is_created() throws IOException {
         DevicePoolConfig config = DevicePoolConfigProperties.load(getClass().getClassLoader());
         Ec2ReservationService service = Ec2ReservationService.builder().ec2(ec2).fromConfig(config);
-        assertEquals(PlatformOS.of("unix", "armv7"), service.platformOS());
+        assertEquals(PlatformOS.of("unix", "armv7"), service.platform());
         assertEquals(8022, service.port());
         assertEquals("proxy-jump.example.com", service.proxyJump());
     }


### PR DESCRIPTION
Noticed inconsistent patter for setting and using `PlatformOS` across components. This fixes it.