### PR TITLE
chore: stage for release

### DIFF
--- a/device-pool-api/pom.xml
+++ b/device-pool-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-cli/pom.xml
+++ b/device-pool-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-cli/src/main/java/me/philcali/device/pool/cli/DeviceLabCLI.java
+++ b/device-pool-cli/src/main/java/me/philcali/device/pool/cli/DeviceLabCLI.java
@@ -42,6 +42,7 @@ import java.util.Optional;
  */
 @CommandLine.Command(
         name = "device-lab",
+        version = "1.0.0",
         description = "Device Lab CLI for the control plane",
         subcommands = {CommandLine.HelpCommand.class}
 )

--- a/device-pool-client/pom.xml
+++ b/device-pool-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-ddb/pom.xml
+++ b/device-pool-ddb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-ec2/pom.xml
+++ b/device-pool-ec2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-examples/device-pool-examples-cli/pom.xml
+++ b/device-pool-examples/device-pool-examples-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-examples</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-examples/device-pool-examples-cli/src/main/java/me/philcali/device/pool/example/ExampleApp.java
+++ b/device-pool-examples/device-pool-examples-cli/src/main/java/me/philcali/device/pool/example/ExampleApp.java
@@ -16,7 +16,7 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
         name = "device-pool-examples",
-        version = "1.0-SNAPSHOT",
+        version = "1.0.0",
         description = "Local app containing examples to show case device pools.",
         subcommands = { Ec2.class, Lab.class, Local.class }
 )

--- a/device-pool-examples/device-pool-examples-infra/pom.xml
+++ b/device-pool-examples/device-pool-examples-infra/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>device-pool-examples</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <groupId>me.philcali</groupId>
     </parent>
 

--- a/device-pool-examples/device-pool-examples-infra/src/main/java/me/philcali/device/pool/examples/infra/DevicePoolExamplesInfraStack.java
+++ b/device-pool-examples/device-pool-examples-infra/src/main/java/me/philcali/device/pool/examples/infra/DevicePoolExamplesInfraStack.java
@@ -43,7 +43,7 @@ public class DevicePoolExamplesInfraStack extends Stack {
     public DevicePoolExamplesInfraStack(final Construct scope, final String id, final StackProps props) {
         super(scope, id, props);
 
-        final String version = "1.0-SNAPSHOT";
+        final String version = "1.0.0";
         final String serviceModule = "device-pool-service-backend";
         final String workflowModule = "device-pool-service-events";
 

--- a/device-pool-examples/pom.xml
+++ b/device-pool-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-s3/pom.xml
+++ b/device-pool-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-api/pom.xml
+++ b/device-pool-service/device-pool-service-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-backend/pom.xml
+++ b/device-pool-service/device-pool-service-backend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-client/pom.xml
+++ b/device-pool-service/device-pool-service-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-contract/pom.xml
+++ b/device-pool-service/device-pool-service-contract/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-data/pom.xml
+++ b/device-pool-service/device-pool-service-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-events/pom.xml
+++ b/device-pool-service/device-pool-service-events/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-local/pom.xml
+++ b/device-pool-service/device-pool-service-local/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-api/pom.xml
+++ b/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service-rpc</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-http/pom.xml
+++ b/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service-rpc</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-lambda/pom.xml
+++ b/device-pool-service/device-pool-service-rpc/device-pool-service-rpc-lambda/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service-rpc</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-service/device-pool-service-rpc/pom.xml
+++ b/device-pool-service/device-pool-service-rpc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool-service</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/device-pool-service/pom.xml
+++ b/device-pool-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>

--- a/device-pool-ssh/pom.xml
+++ b/device-pool-ssh/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/device-pool-ssm/pom.xml
+++ b/device-pool-ssm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>device-pool</artifactId>
         <groupId>me.philcali</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>me.philcali</groupId>
     <artifactId>device-pool</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <modules>
         <module>device-pool-api</module>

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -5,8 +5,12 @@
 #     (https://www.apache.org/licenses/LICENSE-2.0)
 #
 
-
 FROM_VERSION=$1
 TO_VERSION=$2
 
-find . -type f | grep -v "target" | grep -v ".git" | grep -v "native-libs" | xargs sed -i "s/$FROM_VERSION/$TO_VERSION/"
+find . -type f \
+ | grep -v "target" \
+ | grep -v ".git" \
+ | grep -v "native-libs" \
+ | grep -v "install\." \
+ | xargs sed -i "s/$FROM_VERSION/$TO_VERSION/"


### PR DESCRIPTION
Kicking off a release review for `1.0.0`

- Ran: `./scrips/bump.sh 1.0-SNAPSHOT 1.0.0`
- Noticed CLI was not versioned... added it
- Noticed the CLI installer was changed.. that was added to bump exclusion

Need to bump CLI installer post release.