### PR TITLE
feat: adding config property file

### DIFF
--- a/device-pool-api/src/main/java/me/philcali/device/pool/DevicePool.java
+++ b/device-pool-api/src/main/java/me/philcali/device/pool/DevicePool.java
@@ -72,32 +72,8 @@ public interface DevicePool extends AutoCloseable {
      */
     List<Device> obtain(ProvisionOutput output) throws ProvisioningException;
 
-    /**
-     * Attempts to create a {@link me.philcali.device.pool.DevicePool} from an input stream, pointing at a properties
-     * file. An application might provide a <code>devices/pool.properties</code> file on the classpath. The contents of
-     * the file for building a valid {@link me.philcali.device.pool.BaseDevicePool} might look like:
-     * <br>
-     * <pre>
-     * device.pool.class=me.philcali.device.pool.BaseDevicePool
-     * device.pool.provision=me.philcali.device.pool.provision.LocalProvisionService
-     * device.pool.provision.local.hosts.host1.address=myhost.example.com
-     * device.pool.provision.local.hosts.host1.platform=unix:armv7
-     * device.pool.connection=me.philcali.device.pool.ssh.ConnectionFactorySSH
-     * device.pool.connection.ssh.user=ec2-user
-     * </pre>
-     * <br>
-     * Then the following code would work:
-     * <br>
-     * <pre>
-     *     DevicePool pool = DevicePool.create();
-     *     List&lt;Device&gt; devices = pool.provisionSync(ProvisionInput.create(), 5, TimeUnit.SECONDS);
-     * </pre>
-     *  @param inputStream
-     * @return
-     */
-    static DevicePool create(InputStream inputStream) {
+    static DevicePool create(DevicePoolConfig config) {
         try {
-            DevicePoolConfig config = DevicePoolConfigProperties.load(inputStream);
             if (config.poolClassName().equals(LocalDevicePool.class.getName())) {
                 return LocalDevicePool.create();
             } else if (config.poolClassName().equals(BaseDevicePool.class.getName())) {
@@ -136,13 +112,43 @@ public interface DevicePool extends AutoCloseable {
                 return builder.build();
             }
             throw new ProvisioningException("Could not create a default " + DevicePool.class.getSimpleName());
-        } catch (IOException
-                | NullPointerException
+        } catch (NullPointerException
                 | ClassNotFoundException
                 | NoSuchMethodException
                 | InvocationTargetException
                 | IllegalAccessException
                 | InstantiationException ie) {
+            throw new ProvisioningException(ie);
+        }
+    }
+
+    /**
+     * Attempts to create a {@link me.philcali.device.pool.DevicePool} from an input stream, pointing at a properties
+     * file. An application might provide a <code>devices/pool.properties</code> file on the classpath. The contents of
+     * the file for building a valid {@link me.philcali.device.pool.BaseDevicePool} might look like:
+     * <br>
+     * <pre>
+     * device.pool.class=me.philcali.device.pool.BaseDevicePool
+     * device.pool.provision=me.philcali.device.pool.provision.LocalProvisionService
+     * device.pool.provision.local.hosts.host1.address=myhost.example.com
+     * device.pool.provision.local.hosts.host1.platform=unix:armv7
+     * device.pool.connection=me.philcali.device.pool.ssh.ConnectionFactorySSH
+     * device.pool.connection.ssh.user=ec2-user
+     * </pre>
+     * <br>
+     * Then the following code would work:
+     * <br>
+     * <pre>
+     *     DevicePool pool = DevicePool.create();
+     *     List&lt;Device&gt; devices = pool.provisionSync(ProvisionInput.create(), 5, TimeUnit.SECONDS);
+     * </pre>
+     * @param inputStream
+     * @return
+     */
+    static DevicePool create(InputStream inputStream) {
+        try {
+            return create(DevicePoolConfigProperties.load(inputStream));
+        } catch (NullPointerException | IOException ie) {
             throw new ProvisioningException(ie);
         }
     }

--- a/device-pool-client/src/main/java/me/philcali/device/pool/client/DeviceLabProvisionService.java
+++ b/device-pool-client/src/main/java/me/philcali/device/pool/client/DeviceLabProvisionService.java
@@ -27,6 +27,7 @@ import me.philcali.device.pool.service.api.model.ProvisionObject;
 import me.philcali.device.pool.service.api.model.QueryParams;
 import me.philcali.device.pool.service.api.model.QueryResults;
 import me.philcali.device.pool.service.api.model.ReservationObject;
+import me.philcali.device.pool.service.client.AwsV4SigningInterceptor;
 import me.philcali.device.pool.service.client.DeviceLabService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,6 +92,7 @@ public abstract class DeviceLabProvisionService implements ProvisionService, Res
                     .flatMap(entry -> {
                         entry.get("endpoint").ifPresent(endpoint -> {
                             deviceLabService(DeviceLabService.create((client, builder) -> {
+                                client.addInterceptor(AwsV4SigningInterceptor.create());
                                 builder.baseUrl(endpoint);
                             }));
                         });

--- a/device-pool-service/device-pool-service-backend/src/main/java/me/philcali/device/pool/service/resource/DeviceLocks.java
+++ b/device-pool-service/device-pool-service-backend/src/main/java/me/philcali/device/pool/service/resource/DeviceLocks.java
@@ -20,7 +20,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
@@ -37,7 +36,6 @@ import javax.ws.rs.core.SecurityContext;
 @Singleton
 @Produces(MediaType.APPLICATION_JSON)
 public class DeviceLocks extends RepositoryResource<LockObject, CreateLockObject, UpdateLockObject> {
-    @Inject
     /**
      * <p>Constructor for DeviceLocks.</p>
      *
@@ -45,6 +43,7 @@ public class DeviceLocks extends RepositoryResource<LockObject, CreateLockObject
      * @param poolRepo a {@link me.philcali.device.pool.service.api.DevicePoolRepo} object
      * @param deviceRepo a {@link me.philcali.device.pool.service.api.DeviceRepo} object
      */
+    @Inject
     public DeviceLocks(
             final LockRepo lockRepo,
             final DevicePoolRepo poolRepo,


### PR DESCRIPTION
Adding support for reading from a config file. A couple of other issues uncovered in this change:

1. The `useSSM` flag was not using SSM ... oops
2. The `password` option was hidden... mistakenly
3. The `DevicePool` had no way to read from the `DevicePoolConfig` directly... oops

I noted that the `DevicePoolConfig` API is not flexible enough. Really, programmatic "read" and "write" should exist as interface options. I kicked that improvement out of the scope of this change, though. There's thinking through the optimal design choice (like a converter / reader / writer thing) which is large enough to stancalone.

Fixes #52 and #45 